### PR TITLE
Fixes bug, adds generative tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,5 +21,8 @@
   
   :profiles {:uberjar {:aot :all}
              :dev {:dependencies [[com.cemerick/piggieback "0.2.2"]
-                                  [figwheel-sidecar "0.5.11"]]
+                                  [figwheel-sidecar "0.5.11"]
+                                  [com.stuartsierra/dependency "0.2.0"]
+                                  [ring/ring-spec "0.0.3"] ; Real-world specs for testing
+                                  [com.gfredericks/test.chuck "0.2.7"]]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}})

--- a/src/pretty_spec/core.cljc
+++ b/src/pretty_spec/core.cljc
@@ -29,7 +29,7 @@
   [:group "("
    [:align (visit p f) :line (visit p kp) :line (visit p vp)
     (when (next args) :line)
-    (->> (partition 2 (rest args))
+    (->> (partition 2 args)
          (map (fn [[optk optv]]
                 [:span (visit p optk) " " (visit p optv)]))
          (interpose :line))

--- a/test/pretty_spec/core_test.clj
+++ b/test/pretty_spec/core_test.clj
@@ -1,7 +1,64 @@
 (ns pretty-spec.core-test
-  (:require [clojure.test :refer :all]
-            [pretty-spec.core :refer :all]))
+  (:require
+            [clojure.spec.alpha :as s]
+            [clojure.test :refer :all]
+            [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]]
+            [com.stuartsierra.dependency :as deps]
+            [pretty-spec.core :refer :all]
+            [clojure.string :as string]
+            [clojure.core.specs.alpha] ; side-effect: loads specs
+            [ring.core.spec]           ; side effect: loads specs
+            [fipp.clojure :as fipp]
+            ))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(defn spec-dependencies [spec]
+  (->> spec
+       s/form
+       (tree-seq coll? seq )
+       (filter #(and (s/get-spec %)
+                     (not= spec %)))
+       distinct))
+
+(defn topo-sort [specs]
+  (deps/topo-sort
+   (reduce
+    (fn [gr spec]
+      (reduce
+       (fn [g d]
+         ;; If this creates a circular reference, then
+         ;; just skip it.
+         (if (deps/depends? g d spec)
+           g
+           (deps/depend g spec d)))
+       gr
+       (spec-dependencies spec)))
+    (deps/graph)
+    specs)))
+
+(defn spec-gen [prefix]
+  (->> (s/registry)
+       (map key)
+       (filter #(string/starts-with? (str %) (str prefix)))
+       topo-sort
+       (filter keyword?)
+       gen/elements))
+
+(defn ignore-whitespace [s]
+    (string/trim (string/replace s #"\s+" " ")))
+
+(deftest clojure-core-specs
+  (checking
+   "all clojure.core specs are printed without losing information"
+   100
+   [spec (spec-gen :clojure.core)]
+   (is (= (ignore-whitespace (with-out-str (fipp/pprint (s/form spec))))
+          (ignore-whitespace (with-out-str (pprint (s/form spec))))))))
+
+(deftest ring-specs
+  (checking
+   "all ring specs are printed without losing information"
+   100
+   [spec (spec-gen :ring)]
+   (is (= (ignore-whitespace (with-out-str (fipp/pprint (s/form spec))))
+          (ignore-whitespace (with-out-str (pprint (s/form spec))))))))

--- a/test/pretty_spec/core_test.clj
+++ b/test/pretty_spec/core_test.clj
@@ -1,15 +1,14 @@
 (ns pretty-spec.core-test
-  (:require
+  (:require [clojure.core.specs.alpha] ; side-effect: loads specs
             [clojure.spec.alpha :as s]
+            [clojure.string :as string]
             [clojure.test :refer :all]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
             [com.stuartsierra.dependency :as deps]
-            [pretty-spec.core :refer :all]
-            [clojure.string :as string]
-            [clojure.core.specs.alpha] ; side-effect: loads specs
-            [ring.core.spec]           ; side effect: loads specs
             [fipp.clojure :as fipp]
+            [pretty-spec.core :refer :all]
+            [ring.core.spec] ; side effect: loads specs
             ))
 
 (defn spec-dependencies [spec]


### PR DESCRIPTION
Repro:

```clojure
(s/def ::sorted-map (s/map-of keyword? any?
                              :into (sorted-map)))
```

I've also added some tests that verify `pretty-spec` works for some real-world tests in two projects. If you don't find those valuable, of course feel free to remove those tests. It does add a few dependencies, but only at test time.